### PR TITLE
Make container logs available

### DIFF
--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -42,6 +42,7 @@ type providerConfig struct {
 	SecurityGroups          []string
 	AssignPublicIPv4Address bool
 	ExecutionRoleArn        string
+	CloudWatchLogGroupName  string
 	PlatformVersion         string
 	OperatingSystem         string
 	CPU                     string
@@ -133,6 +134,7 @@ func (p *FargateProvider) loadConfig(r io.Reader) error {
 	p.clusterName = config.ClusterName
 	p.assignPublicIPv4Address = config.AssignPublicIPv4Address
 	p.executionRoleArn = config.ExecutionRoleArn
+	p.cloudWatchLogGroupName = config.CloudWatchLogGroupName
 	p.platformVersion = config.PlatformVersion
 	p.operatingSystem = config.OperatingSystem
 	p.capacity.cpu = config.CPU

--- a/providers/aws/fargate.toml
+++ b/providers/aws/fargate.toml
@@ -28,6 +28,10 @@ AssignPublicIPv4Address = false
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
 ExecutionRoleArn = ""
 
+# AWS CloudWatch Log Group Name used to store container logs. Optional.
+# If omitted, no container logs will be stored and retrievable.
+CloudWatchLogGroupName = "/ecs/virtual-kubelet-logs"
+
 # Fargate platform version. Optional. Defaults to "LATEST".
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
 PlatformVersion = "LATEST"

--- a/providers/aws/fargate/client.go
+++ b/providers/aws/fargate/client.go
@@ -5,15 +5,18 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
 
 // Client communicates with the regional AWS Fargate service.
 type Client struct {
-	region string
-	svc    *ecs.ECS
-	api    ecsiface.ECSAPI
+	region  string
+	svc     *ecs.ECS
+	api     ecsiface.ECSAPI
+	logsapi cloudwatchlogsiface.CloudWatchLogsAPI
 }
 
 var client *Client
@@ -41,6 +44,9 @@ func newClient(region string) (*Client, error) {
 	client.region = region
 	client.svc = ecs.New(session)
 	client.api = client.svc
+
+	// Create the CloudWatch service client.
+	client.logsapi = cloudwatchlogs.New(session)
 
 	log.Println("Created Fargate service client.")
 

--- a/providers/aws/fargate/pod.go
+++ b/providers/aws/fargate/pod.go
@@ -92,6 +92,18 @@ func NewPod(cluster *Cluster, pod *corev1.Pod) (*Pod, error) {
 			return nil, err
 		}
 
+		if cluster.cloudWatchLogGroupName != "" {
+			// Configure container logs to be sent to the configured Cloudwatch Logs Log Group.
+			cntr.definition.LogConfiguration = &ecs.LogConfiguration{
+				LogDriver: aws.String(ecs.LogDriverAwslogs),
+				Options: map[string]*string{
+					"awslogs-group":         aws.String(cluster.cloudWatchLogGroupName),
+					"awslogs-region":        aws.String(cluster.region),
+					"awslogs-stream-prefix": aws.String(fmt.Sprintf("%s_%s", tag, containerSpec.Name)),
+				},
+			}
+		}
+
 		// Add the container's resource requirements to its pod's total resource requirements.
 		fgPod.taskCPU += *cntr.definition.Cpu
 		fgPod.taskMemory += *cntr.definition.Memory

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -32,6 +32,7 @@ type FargateProvider struct {
 	capacity                capacity
 	assignPublicIPv4Address bool
 	executionRoleArn        string
+	cloudWatchLogGroupName  string
 	platformVersion         string
 	lastTransitionTime      time.Time
 }
@@ -86,6 +87,7 @@ func NewFargateProvider(
 		SecurityGroups:          p.securityGroups,
 		AssignPublicIPv4Address: p.assignPublicIPv4Address,
 		ExecutionRoleArn:        p.executionRoleArn,
+		CloudWatchLogGroupName:  p.cloudWatchLogGroupName,
 		PlatformVersion:         p.platformVersion,
 	}
 
@@ -170,7 +172,7 @@ func (p *FargateProvider) GetPod(namespace, name string) (*corev1.Pod, error) {
 // GetContainerLogs retrieves the logs of a container by name from the provider.
 func (p *FargateProvider) GetContainerLogs(namespace, podName, containerName string, tail int) (string, error) {
 	log.Printf("Received GetContainerLogs request for %s/%s/%s.\n", namespace, podName, containerName)
-	return "", errNotImplemented
+	return p.cluster.GetContainerLogs(namespace, podName, containerName, tail)
 }
 
 // GetPodStatus retrieves the status of a pod by name from the provider.


### PR DESCRIPTION
Store and retrieve container logs using Cloudwatch Logs.

Regarding the overall design, should creating and configuring an CloudWatch Log Group be required or should logs only be stored and retrievable if this is configured? 